### PR TITLE
Modify downloaded CSS template to match rendered style

### DIFF
--- a/css/full.css
+++ b/css/full.css
@@ -38,8 +38,8 @@ a,
 .preprint-navbar .nav > li.open > a:hover,
 .preprint-navbar .nav > li.open > a:focus:not(.active):hover,
 .preprint-navbar .nav > li > a:focus:not(.active):hover {
-  background-color: theme-color5;
-  color: white; }
+  background-color: theme-color4;
+  color: theme-color5; }
 
 #preprint-form-subjects .subject,
 #preprint-form-subjects .subject > .fa,


### PR DESCRIPTION
I think this will fix the issue with Alt. Text Color.

Compare to https://github.com/hmoco/preprints-style-preview/blob/master/css/theme-color4.css and https://github.com/hmoco/preprints-style-preview/blob/master/css/theme-color5.css